### PR TITLE
Att doc em "Primeiros Passos com Git e GitHub"

### DIFF
--- a/materiais-de-apoio/03-primeiros-passos-com-git-e-github.md
+++ b/materiais-de-apoio/03-primeiros-passos-com-git-e-github.md
@@ -40,19 +40,19 @@ O Git oferece várias maneiras de desfazer um commit, dependendo de como você q
 - Reseta o último commit mantendo as mudanças na área de preparação:
  
 ```bash
-$ git reset --soft
+$ git reset --soft <hash_do_commit>
 ```
 
 - Reseta o último commit e move as mudanças para a área de trabalho:
 
 ```bash
-$ git reset --mixed
+$ git reset --mixed <hash_do_commit>
 ```
 
 - Remove completamente o commit e as mudanças associadas:
 
 ```bash
-$ git reset --hard
+$ git reset --hard <hash_do_commit>
 ```
 
 ##

--- a/materiais-de-apoio/03-primeiros-passos-com-git-e-github.md
+++ b/materiais-de-apoio/03-primeiros-passos-com-git-e-github.md
@@ -35,15 +35,22 @@ $ git commit --amend –m"nova mensagem"
 ```
 
 #### Como desfazer um commit
-```bash
-$ git reset
-```
+O Git oferece várias maneiras de desfazer um commit, dependendo de como você quer manipular o histórico.
+
+- Reseta o último commit mantendo as mudanças na área de preparação:
+ 
 ```bash
 $ git reset --soft
 ```
+
+- Reseta o último commit e move as mudanças para a área de trabalho:
+
 ```bash
 $ git reset --mixed
 ```
+
+- Remove completamente o commit e as mudanças associadas:
+
 ```bash
 $ git reset --hard
 ```


### PR DESCRIPTION
Este PR melhora as descrições sobre as opções do comando git reset (--soft, --mixed, --hard), explicando o efeito de cada flag.

Além disso, add <hash_do_commit> nos exemplos de comandos git reset, indicando onde o hash do commit específico deve ser inserido.